### PR TITLE
add tool call export

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,19 +112,19 @@ With the AI tools plugin, your OpenAPI operations are transformed into structure
 
 ```typescript
 // Generated from your OpenAPI spec
-import { getUserTool, createUserTool } from "./client/tools";
+import { getUserTool, createUserToolOptions } from "./client/tools";
 
-import { Agent, webSearchTool, fileSearchTool } from "@openai/agents";
+import { Agent, tool } from "@openai/agents";
 
 // Each tool contains:
 // - name: operation ID
 // - description: from OpenAPI operation
 // - parameters: Zod schema for validation
-// - exec: the actual API function
+// - execute: the actual API function
 
 const agent = new Agent({
-  name: "Travel assistant",
-  tools: [tool(getUserTool), tool(createUserTool)],
+  name: "User Agent",
+  tools: [getUserTool, tool({ ...createUserToolOptions })],
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pushpress/openapi-ts-plugins",
-  "version": "0.1.3",
+  "version": "0.1.4-rc0.0",
   "type": "module",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/tests/client/tools.gen.ts
+++ b/tests/client/tools.gen.ts
@@ -9,6 +9,7 @@ import {
   getUserPosts,
   createPost,
 } from "./sdk.gen";
+import { tool } from "@openai/agents";
 import {
   zListUsersData,
   zCreateUserData,
@@ -19,86 +20,97 @@ import {
   zCreatePostData,
 } from "./zod.gen";
 
-export const listUsersTool =
-  /**
-   * List users
-   * Retrieve a list of users with optional filtering
-   */
-  {
-    name: "listUsers",
-    description: "Retrieve a list of users with optional filtering",
-    parameters: zListUsersData,
-    exec: listUsers,
-  };
+/**
+ * List users
+ * Retrieve a list of users with optional filtering
+ */
+export const listUsersToolOptions = {
+  name: "listUsers",
+  description: "Retrieve a list of users with optional filtering",
+  parameters: zListUsersData,
+  execute: listUsers,
+};
 
-export const createUserTool =
-  /**
-   * Create user
-   * Create a new user
-   */
-  {
-    name: "createUser",
-    description: "Create a new user",
-    parameters: zCreateUserData,
-    exec: createUser,
-  };
+export const listUsersTool = tool(listUsersToolOptions);
 
-export const deleteUserTool =
-  /**
-   * Delete user
-   * Delete a user by ID
-   */
-  {
-    name: "deleteUser",
-    description: "Delete a user by ID",
-    parameters: zDeleteUserData,
-    exec: deleteUser,
-  };
+/**
+ * Create user
+ * Create a new user
+ */
+export const createUserToolOptions = {
+  name: "createUser",
+  description: "Create a new user",
+  parameters: zCreateUserData,
+  execute: createUser,
+  needsApproval: true,
+};
 
-export const getUserByIdTool =
-  /**
-   * Get user by ID
-   * Retrieve a specific user by their ID
-   */
-  {
-    name: "getUserById",
-    description: "Retrieve a specific user by their ID",
-    parameters: zGetUserByIdData,
-    exec: getUserById,
-  };
+export const createUserTool = tool(createUserToolOptions);
 
-export const updateUserTool =
-  /**
-   * Update user
-   * Update an existing user
-   */
-  {
-    name: "updateUser",
-    description: "Update an existing user",
-    parameters: zUpdateUserData,
-    exec: updateUser,
-  };
+/**
+ * Delete user
+ * Delete a user by ID
+ */
+export const deleteUserToolOptions = {
+  name: "deleteUser",
+  description: "Delete a user by ID",
+  parameters: zDeleteUserData,
+  execute: deleteUser,
+  needsApproval: true,
+};
 
-export const getUserPostsTool =
-  /**
-   * Get user posts
-   * Retrieve all posts for a specific user
-   */
-  {
-    name: "getUserPosts",
-    description: "Retrieve all posts for a specific user",
-    parameters: zGetUserPostsData,
-    exec: getUserPosts,
-  };
+export const deleteUserTool = tool(deleteUserToolOptions);
 
-export const createPostTool =
-  /**
-   * Create post
-   * Create a new post
-   */
-  {
-    name: "createPost",
-    description: "Create a new post",
-    parameters: zCreatePostData,
-    exec: createPost,
-  };
+/**
+ * Get user by ID
+ * Retrieve a specific user by their ID
+ */
+export const getUserByIdToolOptions = {
+  name: "getUserById",
+  description: "Retrieve a specific user by their ID",
+  parameters: zGetUserByIdData,
+  execute: getUserById,
+};
+
+export const getUserByIdTool = tool(getUserByIdToolOptions);
+
+/**
+ * Update user
+ * Update an existing user
+ */
+export const updateUserToolOptions = {
+  name: "updateUser",
+  description: "Update an existing user",
+  parameters: zUpdateUserData,
+  execute: updateUser,
+  needsApproval: true,
+};
+
+export const updateUserTool = tool(updateUserToolOptions);
+
+/**
+ * Get user posts
+ * Retrieve all posts for a specific user
+ */
+export const getUserPostsToolOptions = {
+  name: "getUserPosts",
+  description: "Retrieve all posts for a specific user",
+  parameters: zGetUserPostsData,
+  execute: getUserPosts,
+};
+
+export const getUserPostsTool = tool(getUserPostsToolOptions);
+
+/**
+ * Create post
+ * Create a new post
+ */
+export const createPostToolOptions = {
+  name: "createPost",
+  description: "Create a new post",
+  parameters: zCreatePostData,
+  execute: createPost,
+  needsApproval: true,
+};
+
+export const createPostTool = tool(createPostToolOptions);

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -23,5 +23,33 @@ export const handlers = [
     });
   }),
 
+  // Mock GET /users/:id endpoint
+  http.get("https://api.testservice.com/v1/users/:id", ({ params }) => {
+    const { id } = params;
+    if (id === "550e8400-e29b-41d4-a716-446655440000") {
+      return HttpResponse.json({
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        name: "John Doe",
+        email: "john@example.com",
+        status: "active",
+        createdAt: "2023-01-01T00:00:00Z",
+      });
+    }
+    return HttpResponse.json(
+      { message: "User not found" },
+      { status: 404 },
+    );
+  }),
+
+  // Mock POST /users endpoint
+  http.post("https://api.testservice.com/v1/users", async ({ request }) => {
+    const body = await request.json() as any;
+    return HttpResponse.json({
+      id: "550e8400-e29b-41d4-a716-446655440002",
+      ...body,
+      createdAt: "2023-01-03T00:00:00Z",
+    });
+  }),
+
   // Add more API endpoint handlers here as needed
 ];

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -35,15 +35,12 @@ export const handlers = [
         createdAt: "2023-01-01T00:00:00Z",
       });
     }
-    return HttpResponse.json(
-      { message: "User not found" },
-      { status: 404 },
-    );
+    return HttpResponse.json({ message: "User not found" }, { status: 404 });
   }),
 
   // Mock POST /users endpoint
   http.post("https://api.testservice.com/v1/users", async ({ request }) => {
-    const body = await request.json() as any;
+    const body = (await request.json()) as object;
     return HttpResponse.json({
       id: "550e8400-e29b-41d4-a716-446655440002",
       ...body,

--- a/tests/tools/integration.test.ts
+++ b/tests/tools/integration.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import {
+  listUsersToolOptions,
+  createUserToolOptions,
+  getUserByIdToolOptions,
+  deleteUserToolOptions,
+} from "../client/tools.gen";
+
+describe("Tools Plugin Tests", () => {
+  describe("Tool Options", () => {
+    it("should have correct structure for read operations", () => {
+      expect(listUsersToolOptions).toEqual({
+        name: "listUsers",
+        description: "Retrieve a list of users with optional filtering",
+        parameters: expect.any(Object), // zod schema
+        execute: expect.any(Function),
+      });
+
+      expect(getUserByIdToolOptions).toEqual({
+        name: "getUserById",
+        description: "Retrieve a specific user by their ID",
+        parameters: expect.any(Object), // zod schema
+        execute: expect.any(Function),
+      });
+    });
+
+    it("should have needsApproval for mutation operations", () => {
+      expect(createUserToolOptions).toEqual({
+        name: "createUser",
+        description: "Create a new user",
+        parameters: expect.any(Object), // zod schema
+        execute: expect.any(Function),
+        needsApproval: true,
+      });
+
+      expect(deleteUserToolOptions).toEqual({
+        name: "deleteUser",
+        description: "Delete a user by ID",
+        parameters: expect.any(Object), // zod schema
+        execute: expect.any(Function),
+        needsApproval: true,
+      });
+    });
+  });
+
+  describe("Tool Execution", () => {
+    it("should execute listUsers tool successfully", async () => {
+      const result = await listUsersToolOptions.execute({});
+
+      expect(result.data).toEqual({
+        users: [
+          {
+            id: "550e8400-e29b-41d4-a716-446655440000",
+            name: "John Doe",
+            email: "john@example.com",
+            status: "active",
+            createdAt: "2023-01-01T00:00:00Z",
+          },
+          {
+            id: "550e8400-e29b-41d4-a716-446655440001",
+            name: "Jane Smith",
+            email: "jane@example.com",
+            status: "active",
+            createdAt: "2023-01-02T00:00:00Z",
+          },
+        ],
+      });
+    });
+
+    it("should execute getUserById tool successfully", async () => {
+      const result = await getUserByIdToolOptions.execute({
+        path: { userId: "550e8400-e29b-41d4-a716-446655440000" },
+      });
+
+      expect(result.data).toEqual({
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        name: "John Doe",
+        email: "john@example.com",
+        status: "active",
+        createdAt: "2023-01-01T00:00:00Z",
+      });
+    });
+
+    it("should execute createUser tool successfully", async () => {
+      const newUser = {
+        name: "New User",
+        email: "new@example.com",
+        status: "active" as const,
+      };
+
+      const result = await createUserToolOptions.execute({
+        body: newUser,
+      });
+
+      expect(result.data).toEqual({
+        id: expect.any(String),
+        ...newUser,
+        createdAt: expect.any(String),
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
### TL;DR

Updated the tools plugin to align with the latest OpenAI Agents API, adding support for mutation approval and improving the generated code structure.

### What changed?

- Renamed `exec` property to `execute` in tool definitions to match the OpenAI Agents API
- Added `needsApproval: true` flag for mutation operations (POST, PUT, PATCH, DELETE)
- Split tool generation into separate options and tool instances:
  - Each operation now generates both `[name]ToolOptions` and `[name]Tool`
  - Tools are now created using the `tool()` function from `@openai/agents`
- Updated the README example to reflect the new API usage
- Added comprehensive integration tests to verify tool structure and execution

### How to test?

1. Run the test suite to verify the tool generation and execution:
   ```
   npm test
   ```
2. Check that mutation operations (like createUser) have the `needsApproval` flag
3. Verify that all tools are properly wrapped with the `tool()` function
4. Confirm that the generated code follows the updated pattern with separate options and tool instances

### Why make this change?

This change aligns our tools plugin with the latest OpenAI Agents API requirements, particularly adding support for the approval flow for mutation operations. By separating tool options from the tool instances, we provide more flexibility for consumers while ensuring that operations that modify data require explicit approval before execution, improving security and user control.